### PR TITLE
Spacy versions in tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,7 +19,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements_dev.txt
-          pip install -e ."[test]"
       - name: Test with pytest
         run: |
           pytest --verbose

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,6 +19,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements_dev.txt
+          python -m spacy download en_core_web_sm
+          pip install -e ."[test]"
       - name: Test with pytest
         run: |
           pytest --verbose

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,7 +19,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements_dev.txt
-          python -m spacy download en_core_web_sm
           pip install -e ."[test]"
       - name: Test with pytest
         run: |

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,9 +12,10 @@ sphinx-rtd-theme
 awscli==1.27.32
 pre-commit
 pre-commit-hooks
-spacy
+spacy==3.4.0
 pytest
 sqlalchemy==1.4.37
 pymysql==1.0.2
 furo==2022.9.29
 myst_parser
+https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.4.1/en_core_web_sm-3.4.1.tar.gz


### PR DESCRIPTION
As @Aiden-RC pointed out - the tests have an error due to a mismatch in the spacy version and the spacy model version being installed. This should fix that.

---

Thanks for contributing to Nesta's Skills Extractor Library 🙏!

If you have suggested changes to _code_ anywhere outside of the ExtractSkills class, please consult the checklist below.

Checklist ✔️🐍:

- [ ] I have refactored my code out from `notebooks/`
- [ ] I have checked the code runs
- [ ] I have tested the code
- [ ] I have run `pre-commit` and addressed any issues not automatically fixed
- [ ] I have merged any new changes from `dev`
- [ ] I have documented the code
  - [ ] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [ ] I have explained the feature in this PR or (better) in `output/reports/`
- [ ] I have requested a code review

If you have suggested changes to _documentation_ (and/or the ExtractSkills class), please **ALSO** consult the checklist below.

Documentation Checklist ✔️📚:

- [ ] I have run `make html` in `docs`
- [ ] I have manually reviewed the `docs/build/*.html` files locally to ensure they have formatted correctly
- [ ] I have pushed both relevant files AND their corresponding `docs/build/*.html` files
