### PR TITLE
Add prodigy folder for tagging more skills data using prodigy

### DIFF
--- a/ojd_daps_skills/getters/data_getters.py
+++ b/ojd_daps_skills/getters/data_getters.py
@@ -116,6 +116,20 @@ def load_s3_json(s3, bucket_name, file_name):
     return json.loads(file)
 
 
+def load_prodigy_jsonl_s3_data(s3, bucket_name, file_name):
+    """
+    Load prodigy jsonl formatted data from S3 location.
+
+    s3: S3 boto3 resource
+    bucket_name: The S3 bucket name
+    file_name: S3 key to load
+    """
+    obj = s3.Object(bucket_name, file_name)
+    if fnmatch(file_name, "*.jsonl"):
+        file = obj.get()["Body"].read().decode()
+        return [json.loads(str(item)) for item in file.strip().split("\n")]
+
+
 def load_s3_data(s3, bucket_name, file_name):
     """
     Load data from S3 location.

--- a/ojd_daps_skills/pipeline/skill_ner/README.md
+++ b/ojd_daps_skills/pipeline/skill_ner/README.md
@@ -96,19 +96,19 @@ Using the combined labelled data, we can fine-tune a Spacy model to extract skil
 The model can be trained by running:
 
 ```
-python ojd_daps_skills/pipeline/skill_ner/ner_spacy.py --labelled_date_filename "escoe_extension/outputs/labelled_job_adverts/combined_labels_20230803.json" --convert_multiskill --train_prop 0.8 --drop_out 0.1 --learn_rate 0.001 --num_its 100
+python ojd_daps_skills/pipeline/skill_ner/ner_spacy.py --labelled_date_filename "escoe_extension/outputs/labelled_job_adverts/combined_labels_20230808.json" --convert_multiskill --train_prop 0.8 --drop_out 0.1 --learn_rate 0.001 --num_its 100 --save_s3
 ```
 
-This will save out the model in a time stamped folder, e.g. `outputs/models/ner_model/20220825/`, it also saves out the evaluation results and some general information about the model training in the file `outputs/models/ner_model/20220825/train_details.json`.
+This will save out the model in a time stamped folder, e.g. `outputs/models/ner_model/20230808/`, it also saves out the evaluation results and some general information about the model training in the file `outputs/models/ner_model/20230808/train_details.json`.
 
-By default this won't sync the newly trained model to S3, but by adding `--save_s3` it will sync the `outputs/models/ner_model/20220825/` to S3.
+By default this won't sync the newly trained model to S3, but by adding `--save_s3` it will sync the `outputs/models/ner_model/20230808/` to S3.
 
-This model can be used by running:
+A trained model can be used by running:
 
 ```python
 >>> from ojd_daps_skills.pipeline.skill_ner.ner_spacy import JobNER
 >>> job_ner = JobNER()
->>> nlp = job_ner.load_model('outputs/models/ner_model/20220825/', s3_download=True)
+>>> nlp = job_ner.load_model('outputs/models/ner_model/20230808/', s3_download=True)
 >>> text = "We want someone with good communication and maths skills"
 >>> pred_ents = job_ner.predict(text)
 >>> pred_ents
@@ -126,7 +126,7 @@ The `s3_download=True` argument will mean this model will be first downloaded fr
 Running
 
 ```
-python ojd_daps_skills/pipeline/skill_ner/get_skills.py --model_path outputs/models/ner_model/20220825/ --output_file_dir escoe_extension/outputs/data/skill_ner/skill_predictions/ --job_adverts_filename escoe_extension/inputs/data/skill_ner/data_sample/20220622_sampled_job_ads.json
+python ojd_daps_skills/pipeline/skill_ner/get_skills.py --model_path outputs/models/ner_model/20230808/ --output_file_dir escoe_extension/outputs/data/skill_ner/skill_predictions/ --job_adverts_filename escoe_extension/inputs/data/skill_ner/data_sample/20220622_sampled_job_ads.json
 ```
 
 will make skill predictions on the data in `job_adverts_filename` (an output of `create_data_sample.py`) using the model loaded from `model_path`. By default this will look for the model on S3, but if you want to load a locally stored model just add `--use_local_model`.

--- a/ojd_daps_skills/pipeline/skill_ner/README.md
+++ b/ojd_daps_skills/pipeline/skill_ner/README.md
@@ -96,7 +96,7 @@ Using the combined labelled data, we can fine-tune a Spacy model to extract skil
 The model can be trained by running:
 
 ```
-python ojd_daps_skills/pipeline/skill_ner/ner_spacy.py --labelled_date_filename "escoe_extension/outputs/labelled_job_adverts/combined_labels_20220824.json" --convert_multiskill --train_prop 0.8 --drop_out 0.1 --learn_rate 0.001 --num_its 100
+python ojd_daps_skills/pipeline/skill_ner/ner_spacy.py --labelled_date_filename "escoe_extension/outputs/labelled_job_adverts/combined_labels_20230803.json" --convert_multiskill --train_prop 0.8 --drop_out 0.1 --learn_rate 0.001 --num_its 100
 ```
 
 This will save out the model in a time stamped folder, e.g. `outputs/models/ner_model/20220825/`, it also saves out the evaluation results and some general information about the model training in the file `outputs/models/ner_model/20220825/train_details.json`.

--- a/ojd_daps_skills/pipeline/skill_ner/README.md
+++ b/ojd_daps_skills/pipeline/skill_ner/README.md
@@ -96,6 +96,12 @@ Using the combined labelled data, we can fine-tune a Spacy model to extract skil
 The model can be trained by running:
 
 ```
+python -m spacy download en_core_web_lg
+```
+
+and then
+
+```
 python ojd_daps_skills/pipeline/skill_ner/ner_spacy.py --labelled_date_filename "escoe_extension/outputs/labelled_job_adverts/combined_labels_20230808.json" --convert_multiskill --train_prop 0.8 --drop_out 0.1 --learn_rate 0.001 --num_its 100 --save_s3
 ```
 

--- a/ojd_daps_skills/pipeline/skill_ner/README.md
+++ b/ojd_daps_skills/pipeline/skill_ner/README.md
@@ -109,14 +109,19 @@ A trained model can be used by running:
 >>> from ojd_daps_skills.pipeline.skill_ner.ner_spacy import JobNER
 >>> job_ner = JobNER()
 >>> nlp = job_ner.load_model('outputs/models/ner_model/20230808/', s3_download=True)
->>> text = "We want someone with good communication and maths skills"
+>>> text = "We want someone with good communication and maths skills. There are job benefits such as a pension and cycle to work scheme. We would like someone with experience in marketing."
 >>> pred_ents = job_ner.predict(text)
 >>> pred_ents
-[{'label': 'SKILL', 'start': 21, 'end': 39}, {'label': 'SKILL', 'start': 44, 'end': 56}]
+[{'label': 'SKILL', 'start': 26, 'end': 39},
+ {'label': 'SKILL', 'start': 44, 'end': 56},
+ {'label': 'BENEFIT', 'start': 103, 'end': 123},
+ {'label': 'EXPERIENCE', 'start': 152, 'end': 175}]
 >>> for ent in pred_ents:
 >>>     print(text[ent['start']:ent['end']])
-good communication
+communication
 maths skills
+cycle to work scheme
+experience in marketing
 ```
 
 The `s3_download=True` argument will mean this model will be first downloaded from S3, so you don't have to have it locally to begin with.

--- a/ojd_daps_skills/pipeline/skill_ner/combine_labels.py
+++ b/ojd_daps_skills/pipeline/skill_ner/combine_labels.py
@@ -30,7 +30,7 @@ labelled_data_s3_folders = {
 
 # The Prodigy labelled data
 prodigy_labelled_data_s3_folders = [
-    "escoe_extension/outputs/labelled_job_adverts/prodigy/labelled_dataset_skills_030823.jsonl"
+    "escoe_extension/outputs/labelled_job_adverts/prodigy/labelled_dataset_skills_080823.jsonl"
 ]
 
 

--- a/ojd_daps_skills/pipeline/skill_ner/combine_labels.py
+++ b/ojd_daps_skills/pipeline/skill_ner/combine_labels.py
@@ -29,9 +29,7 @@ labelled_data_s3_folders = {
 }
 
 # The Prodigy labelled data
-prodigy_labelled_data_s3_folders = [
-    "escoe_extension/outputs/labelled_job_adverts/prodigy/labelled_dataset_skills_080823.jsonl"
-]
+prodigy_labelled_data_s3_folder = "escoe_extension/outputs/labelled_job_adverts/prodigy/labelled_dataset_skills_080823.jsonl"
 
 
 def load_original_metadata(labelled_data_s3_folders):
@@ -124,7 +122,7 @@ def combine_results(labelled_data_s3_folders, keep_id_dict, metadata_jobids):
     return job_labels
 
 
-def load_format_prodigy(prodigy_labelled_data_s3_folders):
+def load_format_prodigy(prodigy_labelled_data_s3_folder):
     """
     Load all prodigy labels
     Since these were labelled in 5 sentence chunks, then sort them into a nested dict
@@ -133,13 +131,12 @@ def load_format_prodigy(prodigy_labelled_data_s3_folders):
     """
     s3 = get_s3_resource()
     prodigy_data_chunks = defaultdict(dict)
-    for prodigy_labelled_data_s3_folder in prodigy_labelled_data_s3_folders:
-        prodigy_data = load_prodigy_jsonl_s3_data(
-            s3, bucket_name, prodigy_labelled_data_s3_folder
-        )
-        for p in prodigy_data:
-            if p["answer"] == "accept":
-                prodigy_data_chunks[str(p["meta"]["id"])][p["meta"]["chunk"]] = p
+    prodigy_data = load_prodigy_jsonl_s3_data(
+        s3, bucket_name, prodigy_labelled_data_s3_folder
+    )
+    for p in prodigy_data:
+        if p["answer"] == "accept":
+            prodigy_data_chunks[str(p["meta"]["id"])][p["meta"]["chunk"]] = p
     return prodigy_data_chunks
 
 
@@ -213,7 +210,7 @@ if __name__ == "__main__":
         labelled_data_s3_folders, keep_id_dict, metadata_jobids
     )
 
-    prodigy_data = load_format_prodigy(prodigy_labelled_data_s3_folders)
+    prodigy_data = load_format_prodigy(prodigy_labelled_data_s3_folder)
     prodigy_job_labels = combine_prodigy_spans(prodigy_data)
 
     # Merge label-studio and prodigy labels

--- a/ojd_daps_skills/pipeline/skill_ner/combine_labels.py
+++ b/ojd_daps_skills/pipeline/skill_ner/combine_labels.py
@@ -13,19 +13,25 @@ from ojd_daps_skills.getters.data_getters import (
     load_s3_json,
     load_s3_data,
     save_to_s3,
+    load_prodigy_jsonl_s3_data,
 )
 
 from ojd_daps_skills import bucket_name
 
 s3 = get_s3_resource()
 
-# The labelling outputs and the metadata files relevant for their inputs
+# The Label-Studio labelling outputs and the metadata files relevant for their inputs
 labelled_data_s3_folders = {
     "escoe_extension/outputs/skill_span_labels/": "escoe_extension/outputs/data/skill_ner/label_chunks/20220624_0_sample_labelling_metadata.json",
     "escoe_extension/outputs/labelled_job_adverts/LIZ_skill_spans/": "escoe_extension/outputs/data/skill_ner/label_chunks/20220819_3_sample_labelling_metadata.json",
     "escoe_extension/outputs/labelled_job_adverts/INDIA_skill_spans/": "escoe_extension/outputs/data/skill_ner/label_chunks/20220819_1_sample_labelling_metadata.json",
     "escoe_extension/outputs/labelled_job_adverts/CATH_skill_spans/": "escoe_extension/outputs/data/skill_ner/label_chunks/20220819_0_sample_labelling_metadata.json",
 }
+
+# The Prodigy labelled data
+prodigy_labelled_data_s3_folders = [
+    "escoe_extension/outputs/labelled_job_adverts/prodigy/labelled_dataset_skills_030823.jsonl"
+]
 
 
 def load_original_metadata(labelled_data_s3_folders):
@@ -112,9 +118,88 @@ def combine_results(labelled_data_s3_folders, keep_id_dict, metadata_jobids):
                 job_labels[job_id] = {
                     "text": job_advert_labels["task"]["data"]["text"],
                     "labels": job_advert_labels["result"],
+                    "type": "label-studio",
                 }
 
     return job_labels
+
+
+def load_format_prodigy(prodigy_labelled_data_s3_folders):
+    """
+    Load all prodigy labels
+    Since these were labelled in 5 sentence chunks, then sort them into a nested dict
+    with the job advert id and the sentence chunk number
+
+    """
+    s3 = get_s3_resource()
+    prodigy_data_chunks = defaultdict(dict)
+    for prodigy_labelled_data_s3_folder in prodigy_labelled_data_s3_folders:
+        prodigy_data = load_prodigy_jsonl_s3_data(
+            s3, bucket_name, prodigy_labelled_data_s3_folder
+        )
+        for p in prodigy_data:
+            if p["answer"] == "accept":
+                prodigy_data_chunks[str(p["meta"]["id"])][p["meta"]["chunk"]] = p
+    return prodigy_data_chunks
+
+
+def combine_prodigy_spans(prodigy_data_chunks):
+    """
+    Since the prodigy data was labelled in 5 sentence chunks, we need
+    to merge all of these chunks per advert including updating the span start and end
+    characters to fit with merged text
+    """
+
+    not_equal_spans_count = 0
+    prodigy_job_labels = {}
+    for job_id, job_adv_labels in prodigy_data_chunks.items():
+        # Make sure the sentence chunks are in the correct order
+        job_adv_labels = {k: job_adv_labels[k] for k in sorted(job_adv_labels)}
+
+        # Combine texts and spans for each job advert
+        full_text = []
+        all_labels = []
+        total_chars = 0
+        for chunk_labels in job_adv_labels.values():
+            full_text.append(chunk_labels["text"])
+            for spans_info in chunk_labels["spans"]:
+                all_labels.append(
+                    {
+                        "value": {
+                            "start": spans_info["start"] + total_chars,
+                            "end": spans_info["end"] + total_chars,
+                            "text": chunk_labels["text"][
+                                spans_info["start"] : spans_info["end"]
+                            ],
+                            "labels": [spans_info["label"]],
+                        },
+                        "id": (chunk_labels["_input_hash"], chunk_labels["_task_hash"]),
+                        "origin": chunk_labels["_annotator_id"],
+                    }
+                )
+            total_chars += (
+                len(chunk_labels["text"]) + 2
+            )  # plus two since we combine the 5 sentence chunks together with ". " at the end
+
+        full_text = ". ".join(full_text)
+
+        # checks
+        for v in all_labels:
+            if v["value"]["text"] != full_text[v["value"]["start"] : v["value"]["end"]]:
+                not_equal_spans_count += 1
+        if not_equal_spans_count != 0:
+            print(
+                f"There were {not_equal_spans_count} issues with merging these spans. Please investigate"
+            )
+
+        # Final output
+        prodigy_job_labels[job_id] = {
+            "text": full_text,
+            "labels": all_labels,
+            "type": "prodigy",
+        }
+
+    return prodigy_job_labels
 
 
 if __name__ == "__main__":
@@ -127,6 +212,13 @@ if __name__ == "__main__":
     job_labels = combine_results(
         labelled_data_s3_folders, keep_id_dict, metadata_jobids
     )
+
+    prodigy_data = load_format_prodigy(prodigy_labelled_data_s3_folders)
+    prodigy_job_labels = combine_prodigy_spans(prodigy_data)
+
+    # Merge label-studio and prodigy labels
+    job_labels.update(prodigy_job_labels)
+    print(f"We will be using data from {len(job_labels)} job adverts")
 
     from datetime import datetime as date
 

--- a/ojd_daps_skills/pipeline/skill_ner/ner_spacy.py
+++ b/ojd_daps_skills/pipeline/skill_ner/ner_spacy.py
@@ -186,6 +186,7 @@ class JobNER(object):
             text, ent_list, self.all_labels = self.process_data(
                 label_data, self.all_labels
             )
+
             data.append(
                 (
                     text,
@@ -195,7 +196,6 @@ class JobNER(object):
                     },
                 )
             )
-
         return data
 
     def get_test_train(self, data):
@@ -249,17 +249,8 @@ class JobNER(object):
         # Getting the ner component
         ner = self.nlp.get_pipe("ner")
 
-        # Add the new labels to ner (don't train the MULTISKILL)
-        self.train_labels = self.all_labels.copy()
-        if self.convert_multiskill:
-            self.train_labels.remove("MULTISKILL")
-
-        for label in self.train_labels:
-            ner.add_label(label)
-
         # Resume training
         self.optimizer = self.nlp.resume_training()
-        move_names = list(ner.move_names)
 
     def train_multiskill_classifier(self, train_data, test_data):
         """
@@ -341,6 +332,7 @@ class JobNER(object):
         self.drop_out = drop_out
         self.num_its = num_its
         self.learn_rate = learn_rate
+
         # List of pipes you want to train
         pipe_exceptions = ["ner"]
         # List of pipes which should remain unaffected in training
@@ -489,7 +481,6 @@ class JobNER(object):
                 "ms_classifier_train_evaluation": self.ms_classifier_train_evaluation,
                 "ms_classifier_test_evaluation": self.ms_classifier_test_evaluation,
                 "seen_job_ids": self.seen_job_ids,
-                "losses": self.all_losses,
             }
         )
         save_json_dict(
@@ -586,7 +577,9 @@ if __name__ == "__main__":
         convert_multiskill=args.convert_multiskill,
         train_prop=float(args.train_prop),
     )
+
     data = job_ner.load_data()
+
     train_data, test_data = job_ner.get_test_train(data)
 
     job_ner.prepare_model()
@@ -604,4 +597,5 @@ if __name__ == "__main__":
     date_stamp = str(date.today().date()).replace("-", "")
     output_folder = f"outputs/models/ner_model/{date_stamp}"
     results = job_ner.evaluate(test_data)
+
     job_ner.save_model(output_folder, args.save_s3)

--- a/ojd_daps_skills/pipeline/skill_ner/ner_spacy.py
+++ b/ojd_daps_skills/pipeline/skill_ner/ner_spacy.py
@@ -602,6 +602,6 @@ if __name__ == "__main__":
     from datetime import datetime as date
 
     date_stamp = str(date.today().date()).replace("-", "")
-    output_folder = f"outputs/models/ner_model/{date_stamp}_3"
+    output_folder = f"outputs/models/ner_model/{date_stamp}"
     results = job_ner.evaluate(test_data)
     job_ner.save_model(output_folder, args.save_s3)

--- a/ojd_daps_skills/pipeline/skill_ner/ner_spacy_utils.py
+++ b/ojd_daps_skills/pipeline/skill_ner/ner_spacy_utils.py
@@ -102,9 +102,10 @@ def fix_entity_annotations(text, ents):
 
         # If the char before the start of this span is not a space,
         # Then update from this ent onwards
-        if text[b - 1] != " ":
-            ent_additions[i:] = [ea + 1 for ea in ent_additions[i:]]
-            insert_index_space.append(b)
+        if b != 0:
+            if text[b - 1] != " ":
+                ent_additions[i:] = [ea + 1 for ea in ent_additions[i:]]
+                insert_index_space.append(b)
 
         # If the next char after this span is not a space,
         # then update the start and endings of all entities after this

--- a/ojd_daps_skills/pipeline/skill_ner/prodigy/README.md
+++ b/ojd_daps_skills/pipeline/skill_ner/prodigy/README.md
@@ -62,6 +62,6 @@ You must provide the session url argument (with your name) when labelling the ta
 Output the annotations
 
 ```
-prodigy db-out dataset-skills > ./prodigy_data/labelled_data/dataset_skills.jsonl
-aws s3 cp ./prodigy_data/labelled_data/dataset_skills.jsonl s3://open-jobs-lake/escoe_extension/outputs/labelled_job_adverts/prodigy/labelled_dataset_skills_010823.jsonl
+prodigy db-out dataset-skills > ./prodigy_data/labelled_data/dataset_skills_080823.jsonl
+aws s3 cp ./prodigy_data/labelled_data/dataset_skills_080823.jsonl s3://open-jobs-lake/escoe_extension/outputs/labelled_job_adverts/prodigy/labelled_dataset_skills_080823.jsonl
 ```

--- a/ojd_daps_skills/pipeline/skill_ner/prodigy/README.md
+++ b/ojd_daps_skills/pipeline/skill_ner/prodigy/README.md
@@ -61,5 +61,5 @@ Output the annotations
 
 ```
 prodigy db-out dataset-skills > ./prodigy_data/labelled_data/dataset_skills.jsonl
-
+aws s3 cp ./prodigy_data/labelled_data/dataset_skills.jsonl s3://open-jobs-lake/escoe_extension/outputs/labelled_job_adverts/prodigy/labelled_dataset_skills_250723.jsonl
 ```

--- a/ojd_daps_skills/pipeline/skill_ner/prodigy/README.md
+++ b/ojd_daps_skills/pipeline/skill_ner/prodigy/README.md
@@ -57,9 +57,11 @@ prodigy ner.correct_skills dataset-skills ./prodigy_data/models/20220825_model/ 
 
 Your task is to manually annotate all the SKILLs, MULTISKILL,EXPERIENCE,BENEFIT in the sentences you are provided with. These are job adverts cut up into lengths of 5 sentences (separated by full stop).
 
+You must provide the session url argument (with your name) when labelling the tasks if this is hosted on EC2, e.g. `http://18.XXX:8080/?session=liz`. This makes it so no two labellers will end up annotating the same task. Without it each time someone tried to label the stream of tasks will be exactly the same as another labeller.
+
 Output the annotations
 
 ```
 prodigy db-out dataset-skills > ./prodigy_data/labelled_data/dataset_skills.jsonl
-aws s3 cp ./prodigy_data/labelled_data/dataset_skills.jsonl s3://open-jobs-lake/escoe_extension/outputs/labelled_job_adverts/prodigy/labelled_dataset_skills_250723.jsonl
+aws s3 cp ./prodigy_data/labelled_data/dataset_skills.jsonl s3://open-jobs-lake/escoe_extension/outputs/labelled_job_adverts/prodigy/labelled_dataset_skills_010823.jsonl
 ```

--- a/ojd_daps_skills/pipeline/skill_ner/prodigy/README.md
+++ b/ojd_daps_skills/pipeline/skill_ner/prodigy/README.md
@@ -21,7 +21,7 @@ python ojd_daps_skills/pipeline/skill_ner/prodigy/process_data.py
 
 in the `ojd-daps-skills` conda environment.
 
-This will create `s3://open-jobs-lake/escoe_extension/outputs/labelled_job_adverts/prodigy/processed_sample_20230710.jsonl`.
+This will create `s3://open-jobs-lake/escoe_extension/outputs/labelled_job_adverts/prodigy/processed_sample_20230801.jsonl`.
 
 ## Tagging skills
 
@@ -30,7 +30,7 @@ This is all to be done in your own Prodigy environment, and the commands in this
 First download the data locally to the file location you are running prodigy from
 
 ```
-aws s3 cp s3://open-jobs-lake/escoe_extension/outputs/labelled_job_adverts/prodigy/processed_sample_20230710.jsonl prodigy_data/processed_sample_20230710.jsonl
+aws s3 cp s3://open-jobs-lake/escoe_extension/outputs/labelled_job_adverts/prodigy/processed_sample_20230801.jsonl prodigy_data/processed_sample_20230801.jsonl
 
 ```
 
@@ -52,7 +52,7 @@ aws s3 cp --recursive s3://open-jobs-lake/escoe_extension/outputs/models/ner_mod
 Then open up the tagging task by running.
 
 ```
-prodigy ner.correct_skills dataset-skills ./prodigy_data/models/20220825_model/ prodigy_data/processed_sample_20230710.jsonl --label SKILL,MULTISKILL,EXPERIENCE,BENEFIT -F skill_recipe.py --update
+prodigy ner.correct_skills dataset-skills ./prodigy_data/models/20220825_model/ prodigy_data/processed_sample_20230801.jsonl --label SKILL,MULTISKILL,EXPERIENCE,BENEFIT -F skill_recipe.py --update
 ```
 
 Your task is to manually annotate all the SKILLs, MULTISKILL,EXPERIENCE,BENEFIT in the sentences you are provided with. These are job adverts cut up into lengths of 5 sentences (separated by full stop).

--- a/ojd_daps_skills/pipeline/skill_ner/prodigy/README.md
+++ b/ojd_daps_skills/pipeline/skill_ner/prodigy/README.md
@@ -12,7 +12,7 @@ pip install prodigy -f https://[YOUR_LICENSE_KEY]@download.prodi.gy
 
 ## Data
 
-Merge 5000 random job adverts plus the 375 existing labels into a format readable for Prodigy by running
+Merge 5000 random job adverts into a format readable for Prodigy by running
 
 ```
 python ojd_daps_skills/pipeline/skill_ner/prodigy/process_data.py
@@ -42,13 +42,6 @@ mkdir ./prodigy_data/labelled_data/
 
 ```
 
-Create a new Prodigy dataset with the new job adverts sample:
-
-```
-prodigy db-in dataset-skills ./prodigy_data/processed_sample_20230710.jsonl
-
-```
-
 Copy the original model (trained on 375 job adverts) to this location:
 
 ```
@@ -59,10 +52,10 @@ aws s3 cp --recursive s3://open-jobs-lake/escoe_extension/outputs/models/ner_mod
 Then open up the tagging task by running.
 
 ```
-prodigy ner.correct_skills dataset-skills ./prodigy_data/models/20220825_model/ prodigy_data/processed_sample_20230710.jsonl --label SKILL -F skill_recipe.py --update
+prodigy ner.correct_skills dataset-skills ./prodigy_data/models/20220825_model/ prodigy_data/processed_sample_20230710.jsonl --label SKILL,MULTISKILL,EXPERIENCE,BENEFIT -F skill_recipe.py --update
 ```
 
-Your task is to manually annotate all the SKILLs in the sentences you are provided with. These are job adverts cut up into lengths of 1000 characters.
+Your task is to manually annotate all the SKILLs, MULTISKILL,EXPERIENCE,BENEFIT in the sentences you are provided with. These are job adverts cut up into lengths of 5 sentences (separated by full stop).
 
 Output the annotations
 

--- a/ojd_daps_skills/pipeline/skill_ner/prodigy/process_data.py
+++ b/ojd_daps_skills/pipeline/skill_ner/prodigy/process_data.py
@@ -1,0 +1,57 @@
+"""
+Process a dataset of job adverts for labelling in Prodigy
+
+This includes formatting the random sample of 100,000 (mixed green and brown) job adverts
+created for the green jobs project https://github.com/nestauk/dap_prinz_green_jobs
+"""
+
+import pandas as pd
+import boto3
+
+import json
+import random
+
+from ojd_daps_skills.getters.data_getters import load_s3_data, get_s3_resource
+from ojd_daps_skills.pipeline.skill_ner.ner_spacy_utils import detect_camelcase
+
+
+def clean_text(text):
+    text = text.encode("ascii", "ignore").decode()
+    text = detect_camelcase(text)
+    return text
+
+
+if __name__ == "__main__":
+
+    s3 = get_s3_resource()
+
+    jobs_sample = load_s3_data(
+        s3,
+        "prinz-green-jobs",
+        "outputs/data/ojo_application/deduplicated_sample/mixed_ojo_sample.csv",
+    )
+
+    output_file_dir = "escoe_extension/outputs/labelled_job_adverts/prodigy/processed_sample_20230710.jsonl"
+
+    jobs_sample = jobs_sample[pd.notnull(jobs_sample["description"])]
+    jobs_sample.loc[:, "description"] = jobs_sample["description"].apply(clean_text)
+
+    jobs_sample["meta"] = jobs_sample[["id"]].to_dict(orient="records")
+    jobs_sample_formated = (
+        jobs_sample[["description", "meta"]]
+        .rename(columns={"description": "text"})
+        .to_dict(orient="records")
+    )
+
+    # We aren't going to be able to label all 100,000 of the sample, so cut it down
+    random.seed(42)
+    jobs_sample_formated = random.sample(jobs_sample_formated, 5000)
+
+    output_string = ""
+
+    for line in jobs_sample_formated:
+        output_string += json.dumps(line, ensure_ascii=False)
+        output_string += "\n"
+
+    s3 = boto3.client("s3")
+    s3.put_object(Body=output_string, Bucket="open-jobs-lake", Key=output_file_dir)

--- a/ojd_daps_skills/pipeline/skill_ner/prodigy/skill_recipe.py
+++ b/ojd_daps_skills/pipeline/skill_ner/prodigy/skill_recipe.py
@@ -104,11 +104,10 @@ def ner_correct_skills(
                     for sentence in sentences
                     if len(sentence.strip()) != 0
                 ]
-                for i in range(0, len(sentences), chunk_size):
-                    meta["sent"] = i
+                for sent_id, i in enumerate(range(0, len(sentences), chunk_size)):
                     yield {
                         "text": ". ".join(sentences[i : i + chunk_size]),
-                        "meta": meta,
+                        "meta": {"id": meta["id"], "chunk": sent_id},
                     }
 
         stream = split_text(list(stream))

--- a/ojd_daps_skills/pipeline/skill_ner/prodigy/skill_recipe.py
+++ b/ojd_daps_skills/pipeline/skill_ner/prodigy/skill_recipe.py
@@ -1,0 +1,151 @@
+"""
+This is just ner.correct but modified slightly to split into sentence chunks
+ner.correct can either be the full text (too big) or split by sentences (too small)
+"""
+import copy
+from typing import List, Optional
+import spacy
+from spacy.training import Example
+import prodigy
+from prodigy.components.loaders import JSONL
+from prodigy.components.preprocess import add_tokens, split_sentences
+from prodigy.util import split_string, set_hashes
+
+
+def make_tasks(nlp, stream, labels):
+    """Add a 'spans' key to each example, with predicted entities."""
+    # Process the stream using spaCy's nlp.pipe, which yields doc objects.
+    # If as_tuples=True is set, you can pass in (text, context) tuples.
+    texts = ((eg["text"], eg) for eg in stream)
+    for doc, eg in nlp.pipe(texts, as_tuples=True):
+        task = copy.deepcopy(eg)
+        spans = []
+        for ent in doc.ents:
+            # Ignore if the predicted entity is not in the selected labels.
+            if labels and ent.label_ not in labels:
+                continue
+            # Create a span dict for the predicted entity.
+            spans.append(
+                {
+                    "token_start": ent.start,
+                    "token_end": ent.end - 1,
+                    "start": ent.start_char,
+                    "end": ent.end_char,
+                    "text": ent.text,
+                    "label": ent.label_,
+                }
+            )
+        task["spans"] = spans
+        # Rehash the newly created task so that hashes reflect added data.
+        task = set_hashes(task)
+        yield task
+
+
+# Recipe decorator with argument annotations: (description, argument type,
+# shortcut, type / converter function called on value before it's passed to
+# the function). Descriptions are also shown when typing --help.
+@prodigy.recipe(
+    "ner.correct_skills",
+    dataset=("The dataset to use", "positional", None, str),
+    spacy_model=("The base model", "positional", None, str),
+    source=("The source data as a JSONL file", "positional", None, str),
+    label=("One or more comma-separated labels", "option", "l", split_string),
+    update=("Whether to update the model during annotation", "flag", "UP", bool),
+    exclude=("Names of datasets to exclude", "option", "e", split_string),
+    unsegmented=("Don't split sentences", "flag", "U", bool),
+    component=("Name of NER component in the pipeline", "option", "c", str),
+)
+def ner_correct_skills(
+    dataset: str,
+    spacy_model: str,
+    source: str,
+    label: Optional[List[str]] = None,
+    update: bool = False,
+    exclude: Optional[List[str]] = None,
+    unsegmented: bool = False,
+    component: Optional[str] = "ner",
+):
+    """
+    Create gold-standard data by correcting a model's predictions manually.
+    This recipe used to be called `ner.make-gold`.
+    """
+    # Load the spaCy model.
+    nlp = spacy.load(spacy_model)
+
+    labels = label
+
+    # Get existing model labels, if available.
+    if component not in nlp.pipe_names:
+        raise ValueError(
+            f"Can't find component '{component}' in the provided pipeline."
+        )
+    model_labels = nlp.pipe_labels.get(component, [])
+
+    # Check if we're annotating all labels present in the model or a subset.
+    use_all_model_labels = len(set(labels).intersection(set(model_labels))) == len(
+        model_labels
+    )
+
+    # Load the stream from a JSONL file and return a generator that yields a
+    # dictionary for each example in the data.
+    stream = JSONL(source)
+
+    if not unsegmented:
+        # Custom way to split into chunks of a certain size
+        # its not ideal if these are too big (the model struggles)
+        # or too small (it's hard to label)
+        def split_text(adverts, chunk_size=1000):
+            for advert in adverts:
+                text = advert["text"]
+                meta = advert["meta"]
+                for i in range(0, len(text), chunk_size):
+                    meta["sent"] = i
+                    yield {"text": text[i : i + chunk_size], "meta": meta}
+
+        stream = split_text(list(stream))
+
+    # Tokenize the incoming examples and add a "tokens" property to each
+    # example. Also handles pre-defined selected spans. Tokenization allows
+    # faster highlighting, because the selection can "snap" to token boundaries.
+    stream = add_tokens(nlp, stream)
+
+    # Add the entities predicted by the model to the tasks in the stream.
+    stream = make_tasks(nlp, stream, labels)
+
+    def make_update(answers):
+        """Update the model with the received answers to improve future suggestions"""
+        examples = []
+        # Set the default label for the tokens outside the provided spans.
+        default_label = "outside" if use_all_model_labels else "missing"
+        for eg in answers:
+            if eg["answer"] == "accept":
+                # Create a "predicted" doc object and a "reference" doc objects to be used
+                # as a training example in the model update. If your examples contain tokenization
+                # make sure not to loose this information by initializing the doc object from scratch.
+                pred = nlp.make_doc(eg["text"])
+                ref = nlp.make_doc(eg["text"])
+                spans = [
+                    pred.char_span(span["start"], span["end"], label=span["label"])
+                    for span in eg.get("spans", [])
+                ]
+                # Use the information in spans to set named entites in the document specifying
+                # how to handle the tokens outside the provided spans.
+                ref.set_ents(spans, default=default_label)
+                examples.append(Example(pred, ref))
+        nlp.update(examples)
+
+    return {
+        "view_id": "ner_manual",  # Annotation interface to use
+        "dataset": dataset,  # Name of dataset to save annotations
+        "stream": stream,  # Incoming stream of examples
+        "update": make_update
+        if update
+        else None,  # Update the model in the loop if required
+        "exclude": exclude,  # List of dataset names to exclude
+        "config": {  # Additional config settings, mostly for app UI
+            "lang": nlp.lang,
+            "labels": labels,  # Selectable label options
+            "exclude_by": "input",  # Hash value to filter out seen examples
+            "auto_count_stream": not update,  # Whether to recount the stream at initialization
+        },
+    }

--- a/ojd_daps_skills/pipeline/skill_ner/prodigy/skill_recipe.py
+++ b/ojd_daps_skills/pipeline/skill_ner/prodigy/skill_recipe.py
@@ -94,13 +94,22 @@ def ner_correct_skills(
         # Custom way to split into chunks of a certain size
         # its not ideal if these are too big (the model struggles)
         # or too small (it's hard to label)
-        def split_text(adverts, chunk_size=1000):
+        def split_text(adverts, chunk_size=5):
             for advert in adverts:
                 text = advert["text"]
                 meta = advert["meta"]
-                for i in range(0, len(text), chunk_size):
+                sentences = text.split(".")
+                sentences = [
+                    sentence.strip()
+                    for sentence in sentences
+                    if len(sentence.strip()) != 0
+                ]
+                for i in range(0, len(sentences), chunk_size):
                     meta["sent"] = i
-                    yield {"text": text[i : i + chunk_size], "meta": meta}
+                    yield {
+                        "text": ". ".join(sentences[i : i + chunk_size]),
+                        "meta": meta,
+                    }
 
         stream = split_text(list(stream))
 

--- a/outputs/reports/skills_extraction.md
+++ b/outputs/reports/skills_extraction.md
@@ -60,6 +60,7 @@ A summary of the experiments with training the model is below.
 
 | Date (model name) | Base model     | Training size   | Evaluation size | Number of iterations | Drop out rate | Learning rate | Convert multiskill? | Other info                                                                                       | Skill F1 | Experience F1 | All F1 | Multiskill test score |
 | ----------------- | -------------- | --------------- | --------------- | -------------------- | ------------- | ------------- | ------------------- | ------------------------------------------------------------------------------------------------ | -------- | ------------- | ------ | --------------------- |
+| 20230808          | en_core_web_lg | 400 (7149 ents) | 100 (1805 ents) | 100                  | 0.1           | 0.001         | True                | More data, different base model, BENEFIT label data                                              | 0.61     | 0.52          | 0.59   | 0.94                  |
 | 20220825          | blank en       | 300 (4508 ents) | 75 (1133 ents)  | 100                  | 0.1           | 0.001         | True                | Changed hyperparams, more data                                                                   | 0.59     | 0.51          | 0.56   | 0.91                  |
 | 20220729\*        | blank en       | 196 (2850 ents) | 49 (636 ents)   | 50                   | 0.3           | 0.001         | True                | More data, padding in cleaning but do fix_entity_annotations after fix_all_formatting to sort it | 0.57     | 0.44          | 0.54   | 0.87                  |
 | 20220729_nopad    | blank en       | 196             | 49              | 50                   | 0.3           | 0.001         | True                | No padding in cleaning, more data                                                                | 0.52     | 0.33          | 0.45   | 0.87                  |
@@ -68,6 +69,15 @@ A summary of the experiments with training the model is below.
 | 20220704          | blank en       | 182             | 45              | 50                   | 0.3           | 0.001         | True                | Camel case cleaned                                                                               | 0.54     | 0.39          | 0.52   |                       |
 | 20220630          | blank en       | 180             | 45              | 50                   | 0.3           | 0.001         | True                |                                                                                                  | 0.49     | 0.39          | 0.48   |                       |
 | 20220629          | blank en       | 156             | 39              | 50                   | 0.3           | 0.001         | True                |                                                                                                  | 0.52     | 0.45          | 0.51   |                       |
+
+More in-depth metrics for `20230808`:
+
+| Entity     | F1    | Precision | Recall |
+| ---------- | ----- | --------- | ------ |
+| Skill      | 0.612 | 0.712     | 0.537  |
+| Experience | 0.524 | 0.647     | 0.441  |
+| Benefit    | 0.531 | 0.708     | 0.425  |
+| All        | 0.590 | 0.680     | 0.521  |
 
 More in-depth metrics for `20220825`:
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,7 +12,7 @@ sphinx-rtd-theme
 awscli==1.27.32
 pre-commit
 pre-commit-hooks
-spacy
+spacy==3.4.0
 pytest
 sqlalchemy==1.4.37
 pymysql==1.0.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,7 +12,7 @@ sphinx-rtd-theme
 awscli==1.27.32
 pre-commit
 pre-commit-hooks
-spacy==3.4.0
+spacy
 pytest
 sqlalchemy==1.4.37
 pymysql==1.0.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -18,3 +18,4 @@ sqlalchemy==1.4.37
 pymysql==1.0.2
 furo==2022.9.29
 myst_parser
+typing_extensions<4.6.0


### PR DESCRIPTION
Fixes #192 

- `combine_labels.py` now includes adding in the new prodigy labels
- `ner_spacy.py` uses "en_core_web_lg" as the base model + uses a fixed random seed + a few small bug fixes
- `pipeline/skill_ner/prodigy/` folder created with NER prodigy labelling instructions, a recipe, and a data processing script
- A new model has been trained called `20230808`. I've added #197 as a separate issue +PR to update all the model versions everywhere (as I wanted to make this PR separate)
- I noticed an error with the pytest github action. The fix was found in [this](https://github.com/explosion/spaCy/issues/12659) and [this](https://github.com/explosion/spaCy/issues/2370). (adding `typing_extensions<4.6.0` and `spacy==3.4.0` to requirements_dev.txt)
- The github action then raised another error - looks like its the same as whats discussed here https://github.com/nestauk/ojd_daps_skills/issues/194

## Note for reviewer:

- Check code looks ok
- Try running:
```
from ojd_daps_skills.pipeline.skill_ner.ner_spacy import JobNER
job_ner = JobNER()
nlp = job_ner.load_model('outputs/models/ner_model/20230808/', s3_download=True)
text = "We want someone with good communication and maths skills. There are job benefits such as a pension and cycle to work scheme. We would like someone with experience in marketing."
pred_ents = job_ner.predict(text)
```
You should get:
```
>>> pred_ents
[{'label': 'SKILL', 'start': 26, 'end': 39},
 {'label': 'SKILL', 'start': 44, 'end': 56},
 {'label': 'BENEFIT', 'start': 103, 'end': 123},
 {'label': 'EXPERIENCE', 'start': 152, 'end': 175}]
>>> for ent in pred_ents:
>>>     print(text[ent['start']:ent['end']])
communication
maths skills
cycle to work scheme
experience in marketing
```

## Prodigy labels and new NER model

- In prodigy BENEFIT entities were also labelled. This causes a slight problem since the label-studio data doesn't have BENEFIT labels. I opted to train the NER model with BENEFIT label anyway, which means the recall has ended up being really low.
- The number of labelled job adverts has increased from 375 to 500.

Skill metric changes:

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-fbda6b54-7fff-2960-3dda-842ce9a18cae">

  | F1 | Precision | Recall
-- | -- | -- | --
Previous model | 0.59 | 0.68 | 0.52
Newest model | 0.61 | 0.71 | 0.54

</b>

All metrics from the new model:

| Entity     | F1    | Precision | Recall |
| ---------- | ----- | --------- | ------ |
| Skill      | 0.612 | 0.712     | 0.537  |
| Experience | 0.524 | 0.647     | 0.441  |
| Benefit    | 0.531 | 0.708     | 0.425  |
| All        | 0.590 | 0.680     | 0.521  |



---

Thanks for contributing to Nesta's Skills Extractor Library 🙏!

If you have suggested changes to _code_ anywhere outside of the ExtractSkills class, please consult the checklist below.

Checklist ✔️🐍:

- [ ] I have refactored my code out from `notebooks/`
- [ ] I have checked the code runs
- [ ] I have tested the code
- [ ] I have run `pre-commit` and addressed any issues not automatically fixed
- [ ] I have merged any new changes from `dev`
- [ ] I have documented the code
  - [ ] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [ ] I have explained the feature in this PR or (better) in `output/reports/`
- [ ] I have requested a code review

If you have suggested changes to _documentation_ (and/or the ExtractSkills class), please **ALSO** consult the checklist below.

Documentation Checklist ✔️📚:

- [ ] I have run `make html` in `docs`
- [ ] I have manually reviewed the `docs/build/*.html` files locally to ensure they have formatted correctly
- [ ] I have pushed both relevant files AND their corresponding `docs/build/*.html` files
