### PR TITLE
Update typing-extensions version to be compatible with Pydantic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ nervaluate==0.1.8
 s3fs==2022.5.0
 boto3==1.21.21
 toolz==0.12.0
-typing_extensions<=4.6.0
+typing_extensions<=4.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ nervaluate==0.1.8
 s3fs==2022.5.0
 boto3==1.21.21
 toolz==0.12.0
-typing_extensions<4.6.0
+typing_extensions<=4.6.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -17,6 +17,6 @@ sqlalchemy==1.4.37
 pymysql==1.0.2
 furo==2022.9.29
 myst_parser
-typing_extensions<=4.6.0
+typing_extensions<=4.6.1
 setuptools-scm
 build

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -17,6 +17,6 @@ sqlalchemy==1.4.37
 pymysql==1.0.2
 furo==2022.9.29
 myst_parser
-typing_extensions<4.6.0
+typing_extensions<=4.6.0
 setuptools-scm
 build


### PR DESCRIPTION
The dependency of `typing-extensions` has prevented a few people from using the project alongside Pydantic. From v2.0 (Release on [2023-06-30](https://github.com/pydantic/pydantic/releases/tag/v2.0)), Pydantic requires `typing-extensions>=4.6.1` ([reference](https://github.com/pydantic/pydantic/blob/aeb8fd0255bf034212e808b92893283adc9f8d3a/pyproject.toml#L62)).

This PR only aims to match the 4.6.1 requirement of Pydantic.

Partially solve #211 

---

Thanks for contributing to Nesta's Skills Extractor Library 🙏!

If you have suggested changes to _code_ anywhere outside of the ExtractSkills class, please consult the checklist below.

Checklist ✔️🐍:

- [ ] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [x] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [ ] I have documented the code
  - [ ] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained the feature in this PR or (better) in `output/reports/`
- [ ] I have requested a code review

If you have suggested changes to _documentation_ (and/or the ExtractSkills class), please **ALSO** consult the checklist below.

Documentation Checklist ✔️📚:

- [ ] I have run `make html` in `docs`
- [ ] I have manually reviewed the `docs/build/*.html` files locally to ensure they have formatted correctly
- [ ] I have pushed both relevant files AND their corresponding `docs/build/*.html` files
